### PR TITLE
Add a new benchmark to check specific tag values. Closes #25

### DIFF
--- a/controls/expected_label_values.sp
+++ b/controls/expected_label_values.sp
@@ -81,7 +81,7 @@ locals {
         else 'alarm'
       end as status,
       case
-        when bool_and(can_skip) then title || ' resource has no matching label keys.'
+        when bool_and(can_skip) then title || ' has no matching label keys.'
         when bool_and(status) then title || ' has expected label values for labels: ' || array_to_string(array_agg(label_key) filter(where status), ', ') || '.'
         else title || ' has unexpected label values for labels: ' || array_to_string(array_agg(label_key) filter(where not status), ', ') || '.'
       end as reason,

--- a/controls/expected_labels_value.sp
+++ b/controls/expected_labels_value.sp
@@ -1,0 +1,400 @@
+variable "expected_label_values" {
+  type        = map(list(string))
+  description = "Map of expected values for various labels, e.g., {\"environment\": [\"Prod\", \"Staging\", \"Dev%\"]}. SQL wildcards '%' and '_' can be used for matching values. These characters must be escaped for exact matches, e.g., {\"created_by\": [\"test\\_user\"]}."
+
+  default = {
+    "environment": ["dev", "staging", "prod"]
+  }
+}
+
+locals {
+  expected_label_values_sql = <<-EOQ
+    with raw_data as
+    (
+      select
+        self_link,
+        title,
+        labels,
+        row_to_json(json_each($1)) as expected_label_values,
+        __DIMENSIONS__
+      from
+        __TABLE_NAME__
+      where
+        labels is not null
+    ),
+    exploded_expected_label_values as
+    (
+      select
+        self_link,
+        title,
+        expected_label_values ->> 'key' as label_key,
+        jsonb_array_elements_text((expected_label_values ->> 'value')::jsonb) as expected_values,
+        labels ->> (expected_label_values ->> 'key') as current_value,
+        __DIMENSIONS__
+      from
+        raw_data
+    ),
+    analysis as
+    (
+      select
+        self_link,
+        title,
+        current_value like expected_values as has_appropriate_value,
+        case
+          when current_value is null then true
+          else false
+        end as has_no_matching_labels,
+        label_key,
+        current_value,
+        __DIMENSIONS__
+      from
+        exploded_expected_label_values
+    ),
+    status_by_label as
+    (
+      select
+        self_link,
+        title,
+        bool_or(has_appropriate_value) as status,
+        label_key,
+        case
+          when bool_or(has_appropriate_value) then ''
+          else label_key
+        end as reason,
+        bool_or(has_no_matching_labels) as can_skip,
+        current_value,
+        __DIMENSIONS__
+      from
+        analysis
+      group by
+        self_link,
+        title,
+        label_key,
+        current_value,
+        __DIMENSIONS__
+    )
+    select
+      self_link as resource,
+      case
+        when bool_and(can_skip) then 'skip'
+        when bool_and(status) then 'ok'
+        else 'alarm'
+      end as status,
+      case
+        when bool_and(can_skip) then title || ' resource has no matching label keys.'
+        when bool_and(status) then title || ' has expected label values for labels: ' || array_to_string(array_agg(label_key) filter(where status), ', ') || '.'
+        else title || ' has unexpected label values for labels: ' || array_to_string(array_agg(label_key) filter(where not status), ', ') || '.'
+      end as reason,
+      __DIMENSIONS__
+    from
+      status_by_label
+    group by
+      self_link,
+      title,
+      __DIMENSIONS__
+    union all
+    select
+      self_link as resource,
+      'skip' as status,
+      title || ' has no labels.' as reason,
+      __DIMENSIONS__
+    from
+      __TABLE_NAME__
+    where
+      labels is null
+    union all
+    select
+      self_link as resource,
+      'skip' as status,
+      title || ' has labels but no expected label values are set.' as reason,
+      __DIMENSIONS__
+    from
+      __TABLE_NAME__
+    where
+      $1::text = '{}'
+      and labels is not null
+  EOQ
+}
+
+locals {
+  expected_label_values_sql_project  = replace(local.expected_label_values_sql, "__DIMENSIONS__", "project")
+  expected_label_values_sql_location = replace(local.expected_label_values_sql, "__DIMENSIONS__", "location, project")
+}
+
+benchmark "expected_label_values" {
+  title       = "Expected Label Values"
+  description = "Resources should have specific values for some labels."
+  children = [
+    control.bigquery_dataset_expected_label_values,
+    control.bigquery_job_expected_label_values,
+    control.bigquery_table_expected_label_values,
+    control.bigtable_instance_expected_label_values,
+    control.compute_disk_expected_label_values,
+    control.compute_forwarding_rule_expected_label_values,
+    control.compute_image_expected_label_values,
+    control.compute_instance_expected_label_values,
+    control.compute_snapshot_expected_label_values,
+    control.dataproc_cluster_expected_label_values,
+    control.dns_managed_zone_expected_label_values,
+    control.pubsub_subscription_expected_label_values,
+    control.pubsub_topic_expected_label_values,
+    control.sql_database_instance_expected_label_values,
+    control.storage_bucket_expected_label_values
+  ]
+
+  tags = merge(local.gcp_labels_common_tags, {
+    type = "Benchmark"
+  })
+}
+
+control "bigquery_dataset_expected_label_values" {
+  title       = "BigQuery datasets should have appropriate label values"
+  description = "Check if BigQuery datasets have appropriate label values."
+  sql         = replace(local.expected_label_values_sql_location, "__TABLE_NAME__", "gcp_bigquery_dataset")
+  param "expected_label_values" {
+    default = var.expected_label_values
+  }
+}
+
+control "bigquery_job_expected_label_values" {
+  title       = "BigQuery jobs should have appropriate label values"
+  description = "Check if BigQuery jobs have appropriate label values."
+  sql         = replace(local.expected_label_values_sql_location, "__TABLE_NAME__", "gcp_bigquery_job")
+  param "expected_label_values" {
+    default = var.expected_label_values
+  }
+}
+
+control "bigquery_table_expected_label_values" {
+  title       = "BigQuery tables should have appropriate label values"
+  description = "Check if BigQuery tables have appropriate label values."
+  sql         = replace(local.expected_label_values_sql_location, "__TABLE_NAME__", "gcp_bigquery_table")
+  param "expected_label_values" {
+    default = var.expected_label_values
+  }
+}
+
+control "compute_disk_expected_label_values" {
+  title       = "Compute disks should have appropriate label values"
+  description = "Check if Compute disks have appropriate label values."
+  sql         = replace(local.expected_label_values_sql_location, "__TABLE_NAME__", "gcp_compute_disk")
+  param "expected_label_values" {
+    default = var.expected_label_values
+  }
+}
+
+control "compute_forwarding_rule_expected_label_values" {
+  title       = "Compute forwarding rules should have appropriate label values"
+  description = "Check if Compute forwarding rules have appropriate label values."
+  sql         = replace(local.expected_label_values_sql_location, "__TABLE_NAME__", "gcp_compute_forwarding_rule")
+  param "expected_label_values" {
+    default = var.expected_label_values
+  }
+}
+
+control "compute_image_expected_label_values" {
+  title       = "Compute images should have appropriate label values"
+  description = "Check if Compute images have appropriate label values."
+  sql         = <<-EOT
+    with raw_data as
+    (
+      select
+        self_link,
+        title,
+        labels,
+        row_to_json(json_each($1)) as expected_label_values,
+        location,
+        project
+      from
+        gcp_compute_image
+      where
+        labels is not null
+        and source_project = project
+    ),
+    exploded_expected_label_values as
+    (
+      select
+        self_link,
+        title,
+        expected_label_values ->> 'key' as label_key,
+        jsonb_array_elements_text((expected_label_values ->> 'value')::jsonb) as expected_values,
+        labels ->> (expected_label_values ->> 'key') as current_value,
+        location,
+        project
+      from
+        raw_data
+    ),
+    analysis as
+    (
+      select
+        self_link,
+        title,
+        current_value like expected_values as has_appropriate_value,
+        case
+          when current_value is null then true
+          else false
+        end as has_no_matching_labels,
+        label_key,
+        current_value,
+        location,
+        project
+      from
+        exploded_expected_label_values
+    ),
+    status_by_label as
+    (
+      select
+        self_link,
+        title,
+        bool_or(has_appropriate_value) as status,
+        label_key,
+        case
+          when bool_or(has_appropriate_value) then ''
+          else label_key
+        end as reason,
+        bool_or(has_no_matching_labels) as can_skip,
+        current_value,
+        location,
+        project
+      from
+        analysis
+      group by
+        self_link,
+        title,
+        label_key,
+        current_value,
+        location,
+        project
+    )
+    select
+      self_link as resource,
+      case
+        when bool_and(can_skip) then 'skip'
+        when bool_and(status) then 'ok'
+        else 'alarm'
+      end as status,
+      case
+        when bool_and(can_skip) then title || ' resource has no matching label keys.'
+        when bool_and(status) then title || ' has expected label values for labels: ' || array_to_string(array_agg(label_key) filter(where status), ', ') || '.'
+        else title || ' has unexpected label values for labels: ' || array_to_string(array_agg(label_key) filter(where not status), ', ') || '.'
+      end as reason,
+      location,
+      project
+    from
+      status_by_label
+    group by
+      self_link,
+      title,
+      location,
+      project
+    union all
+    select
+      self_link as resource,
+      'skip' as status,
+      title || ' has no labels.' as reason,
+      location,
+      project
+    from
+      gcp_compute_image
+    where
+      labels is null
+      and source_project = project
+    union all
+    select
+      self_link as resource,
+      'skip' as status,
+      title || ' has labels but no expected label values are set.' as reason,
+      location,
+      project
+    from
+      gcp_compute_image
+    where
+      $1::text = '{}'
+      and labels is not null
+      and source_project = project
+  EOT
+  param "expected_label_values" {
+    default = var.expected_label_values
+  }
+}
+
+control "compute_instance_expected_label_values" {
+  title       = "Compute instances should have appropriate label values"
+  description = "Check if Compute instances have appropriate label values."
+  sql         = replace(local.expected_label_values_sql_location, "__TABLE_NAME__", "gcp_compute_instance")
+  param "expected_label_values" {
+    default = var.expected_label_values
+  }
+}
+
+control "compute_snapshot_expected_label_values" {
+  title       = "Compute snapshots should have appropriate label values"
+  description = "Check if Compute snapshots have appropriate label values."
+  sql         = replace(local.expected_label_values_sql_location, "__TABLE_NAME__", "gcp_compute_snapshot")
+  param "expected_label_values" {
+    default = var.expected_label_values
+  }
+}
+
+control "dns_managed_zone_expected_label_values" {
+  title       = "DNS managed zones should have appropriate label values"
+  description = "Check if DNS managed zones have appropriate label values."
+  sql         = replace(local.expected_label_values_sql_location, "__TABLE_NAME__", "gcp_dns_managed_zone")
+  param "expected_label_values" {
+    default = var.expected_label_values
+  }
+}
+
+control "sql_database_instance_expected_label_values" {
+  title       = "SQL database instances should have appropriate label values"
+  description = "Check if SQL database instances have appropriate label values."
+  sql         = replace(local.expected_label_values_sql_location, "__TABLE_NAME__", "gcp_sql_database_instance")
+  param "expected_label_values" {
+    default = var.expected_label_values
+  }
+}
+
+control "storage_bucket_expected_label_values" {
+  title       = "Storage buckets should have appropriate label values"
+  description = "Check if Storage buckets have appropriate label values."
+  sql         = replace(local.expected_label_values_sql_location, "__TABLE_NAME__", "gcp_storage_bucket")
+  param "expected_label_values" {
+    default = var.expected_label_values
+  }
+}
+
+control "bigtable_instance_expected_label_values" {
+  title       = "Bigtable instances should have appropriate label values"
+  description = "Check if Bigtable instances have appropriate label values."
+  sql         = replace(local.expected_label_values_sql_location, "__TABLE_NAME__", "gcp_bigtable_instance")
+  param "expected_label_values" {
+    default = var.expected_label_values
+  }
+}
+
+control "dataproc_cluster_expected_label_values" {
+  title       = "Dataproc clusters should have appropriate label values"
+  description = "Check if Dataproc clusters have appropriate label values."
+  sql         = replace(local.expected_label_values_sql_location, "__TABLE_NAME__", "gcp_dataproc_cluster")
+  param "expected_label_values" {
+    default = var.expected_label_values
+  }
+}
+
+control "pubsub_subscription_expected_label_values" {
+  title       = "Pub/Sub subscriptions should have appropriate label values"
+  description = "Check if Pub/Sub subscriptions have appropriate label values."
+  sql         = replace(local.expected_label_values_sql_location, "__TABLE_NAME__", "gcp_pubsub_subscription")
+  param "expected_label_values" {
+    default = var.expected_label_values
+  }
+}
+
+control "pubsub_topic_expected_label_values" {
+  title       = "Pub/Sub topics should have appropriate label values"
+  description = "Check if Pub/Sub topics have appropriate label values."
+  sql         = replace(local.expected_label_values_sql_location, "__TABLE_NAME__", "gcp_pubsub_topic")
+  param "expected_label_values" {
+    default = var.expected_label_values
+  }
+}

--- a/controls/expected_labels_value.sp
+++ b/controls/expected_labels_value.sp
@@ -274,7 +274,7 @@ control "compute_image_expected_label_values" {
         else 'alarm'
       end as status,
       case
-        when bool_and(can_skip) then title || ' resource has no matching label keys.'
+        when bool_and(can_skip) then title || ' has no matching label keys.'
         when bool_and(status) then title || ' has expected label values for labels: ' || array_to_string(array_agg(label_key) filter(where status), ', ') || '.'
         else title || ' has unexpected label values for labels: ' || array_to_string(array_agg(label_key) filter(where not status), ', ') || '.'
       end as reason,

--- a/mod.sp
+++ b/mod.sp
@@ -17,9 +17,9 @@ mod "gcp_labels" {
   categories    = ["gcp", "tags", "public cloud"]
 
   opengraph {
-    title        = "Steampipe Mod for GCP Labels"
-    description  = "Run label controls across all your GCP projects using Steampipe."
-    image        = "/images/mods/turbot/gcp-labels-social-graphic.png"
+    title       = "Steampipe Mod for GCP Labels"
+    description = "Run label controls across all your GCP projects using Steampipe."
+    image       = "/images/mods/turbot/gcp-labels-social-graphic.png"
   }
 
   require {

--- a/steampipe.spvars.example
+++ b/steampipe.spvars.example
@@ -1,3 +1,13 @@
 mandatory_labels = ["environment", "owner"]
 prohibited_labels = ["password", "key"]
 label_limit = 60
+expected_label_values = {
+  // Simple match
+  "environment": ["dev", "staging", "prod"]
+
+  // Match with SQL wildcard character
+  "cost_center": ["cc-%"]
+
+  // Escaping is required for exact matches on wildcard characters
+  "created_by": ["john\\_doe"]
+}


### PR DESCRIPTION
Output :-

i storage_bucket_expected_label_values

```
steampipe-mod-gcp-labels % steampipe check control.storage_bucket_expected_label_values

+ Storage buckets should have appropriate label values ......... 1 / 17 [==========]
  | 
  ALARM: gcf-v2-sources-979620418102-us-central1 has unexpected label values for labels: cost_center,created_by. ....... US-CENTRAL1 pppppp-aaa
  OK   : dataproc-81d7c6b8-6d8c-4b04-af65-1bf0751bd6fd-us-east1 has expected label values for labels: cost_center, environment. ....... US-EAST1 pppppp-aaa
  SKIP : rk-test-org-tagging-mar23 resource has no matching label keys. ....... ASIA-SOUTH1 pppppp-aaa
  SKIP : us-east1-testcomposer2-00c66489-bucket resource has no matching label keys. ....... US-EAST1 pppppp-aaa
  SKIP : us-east1-testenv-f222e894-bucket resource has no matching label keys. ........ US-EAST1 pppppp-aaa
  SKIP : dataproc-temp-asia-southeast2-979620418102-m0rrtkua has no labels. ..... ASIA-SOUTHEAST2 pppppp-aaa
  SKIP : dataproc-staging-asia-southeast2-979620418102-a1jautgv has no labels. ..... ASIA-SOUTHEAST2 pppppp-aaa
```

ii compute_image_expected_label_values

```
steampipe-mod-gcp-labels % steampipe check control.compute_image_expected_label_values

+ Compute images should have appropriate label values ..................................... 0 / 2 [==========]
  | 
  OK   : image-2 has expected label values for labels: environment. .................................... global pppppp-aaa
  SKIP : image-1 has no labels. ...................................... global pppppp-aaa
```
